### PR TITLE
Fix libsodium buid

### DIFF
--- a/.github/workflows/sodium.yml
+++ b/.github/workflows/sodium.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           choco install visualstudio2022buildtools --package-parameters "--add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --includeRecommended --includeOptional"
 
-      - name: setup-msbuild
+      - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v2
         if: matrix.os == 'windows-latest'
 
@@ -93,7 +93,7 @@ jobs:
       - name: Publish Artifacts
         uses: actions/upload-artifact@v4.4.3
         with:
-          name: sodium-${{ matrix.os }} # Keep naming for consistency 
+          name: sodium-${{ matrix.os }}
           path: output
           compression-level: 9 # Prefer smaller downloads over a shorter workflow runtime
 

--- a/.github/workflows/sodium.yml
+++ b/.github/workflows/sodium.yml
@@ -15,6 +15,11 @@ jobs:
     outputs:
       version: ${{ steps.print-version.outputs.version }}
 
+    strategy:
+      fail-fast: false # Run the other two OSs even if one fails
+      matrix:
+        os: [ windows-latest, ubuntu-latest, macos-latest ]
+
     steps:
       - name: Clone sodium repo
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/sodium.yml
+++ b/.github/workflows/sodium.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     name: Build sodium
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     outputs:
       version: ${{ steps.print-version.outputs.version }}
@@ -32,45 +32,56 @@ jobs:
         run: |
           git fetch --tags 
           echo "version=$(git describe --tags $(git rev-list --tags --max-count=1))" >> $GITHUB_OUTPUT
-      
+
+      - name: Build sodium on Windows
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          choco install visualstudio2022buildtools --package-parameters "--add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --includeRecommended --includeOptional"
+          foreach ($arch in "x64", "ARM64") {
+            New-Item -ItemType Directory -Name output/$arch
+            msbuild builds/msvc/vs2022/libsodium.sln /p:Configuration=DynRelease /p:Platform=$arch /t:Clean,Build # Clean between builds
+            cp bin/$arch/Release/v143/dynamic/libsodium.dll output/$arch/libsodium.dll # TODO: Figure out if we can detect the version part (v143) when it changes
+          }
+
       - name: Build sodium
+        if: matrix.os != 'windows-latest'
         shell: bash
         run: |
-          # TODO: Figure out how to build a "fat" dylib for macos, which can be used on x86_64 and aarch64 https://github.com/ziglang/zig/issues/9169
-          wget -nv https://ziglang.org/download/0.13.0/zig-linux-x86_64-0.13.0.tar.xz
-          tar -xf zig-linux-x86_64-0.13.0.tar.xz -C . --strip-components=1
-          mkdir -p output-{windows,linux,macos}/{x64,ARM64} # Keep x64 and ARM64 naming from zstd/opus workflows for consistency
-          for target in x86_64-windows x86_64-linux x86_64-macos aarch64-windows aarch64-linux aarch64-macos; do
-            # Docs use ReleaseFast instead of ReleaseSafe, so ill use it here as well
-            ./zig build -Doptimize=ReleaseFast -Dtarget=$target -p $target --summary all
-          done
-          cp x86_64-windows/bin/libsodium.dll output-windows/x64/libsodium.dll # No clue why for windows the output is in bin/ and not lib/
-          cp aarch64-windows/bin/libsodium.dll output-windows/ARM64/libsodium.dll
-          cp x86_64-linux/lib/libsodium.so output-linux/x64/libsodium.so
-          cp aarch64-linux/lib/libsodium.so output-linux/ARM64/libsodium.so
-          cp x86_64-macos/lib/libsodium.dylib output-macos/x64/libsodium.dylib
-          cp aarch64-macos/lib/libsodium.dylib output-macos/ARM64/libsodium.dylib
+          if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
+            for arch in x64 ARM64; do
+              mkdir -p output/$arch
+              if [[ "$arch" == "ARM64" ]]; then
+                sudo apt update
+                sudo apt install cmake gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+                ./configure --enable-static=off --host=aarch64-linux-gnu
+              else
+                ./configure --enable-static=off --host=x86_64-linux-gnu
+              fi
+              make -j4
+              cp src/libsodium/.libs/libsodium.so output/$arch/libsodium.so
+              make clean # Clean between builds
+            done
+          else
+            for arch in x64 ARM64; do
+              mkdir -p output/$arch
+              if [[ "$arch" == "ARM64" ]]; then
+                ./configure --enable-static=off --host=arm-apple-darwin
+              else
+                ./configure --enable-static=off --host=x86_64-apple-darwin
+              fi
+              make -j4
+              cp src/libsodium/.libs/libsodium.dylib output/$arch/libsodium.dylib
+              make clean # Clean between builds
+            done
+          fi
 
-      - name: Publish Artifacts for Windows
+      - name: Publish Artifacts
         uses: actions/upload-artifact@v4.4.3
         with:
-          name: sodium-windows-latest # Keep naming for consistency 
-          path: output-windows
+          name: sodium-${{ matrix.os }} # Keep naming for consistency 
+          path: output
           compression-level: 9 # Prefer smaller downloads over a shorter workflow runtime
-
-      - name: Publish Artifacts for Linux
-        uses: actions/upload-artifact@v4.4.3
-        with:
-          name: sodium-ubuntu-latest
-          path: output-linux
-          compression-level: 9
-
-      - name: Publish Artifacts for MacOS
-        uses: actions/upload-artifact@v4.4.3
-        with:
-          name: sodium-macos-latest
-          path: output-macos
-          compression-level: 9
 
   publish-nuget:
     needs: build

--- a/.github/workflows/sodium.yml
+++ b/.github/workflows/sodium.yml
@@ -38,11 +38,20 @@ jobs:
           git fetch --tags 
           echo "version=$(git describe --tags $(git rev-list --tags --max-count=1))" >> $GITHUB_OUTPUT
 
-      - name: Build sodium on Windows
+      - name: Install Visual Studio 2022 Build Tools
         if: matrix.os == 'windows-latest'
         shell: pwsh
         run: |
           choco install visualstudio2022buildtools --package-parameters "--add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --includeRecommended --includeOptional"
+
+      - name: setup-msbuild
+        uses: microsoft/setup-msbuild@v2
+        if: matrix.os == 'windows-latest'
+
+      - name: Build sodium on Windows
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
           foreach ($arch in "x64", "ARM64") {
             New-Item -ItemType Directory -Name output/$arch
             msbuild builds/msvc/vs2022/libsodium.sln /p:Configuration=DynRelease /p:Platform=$arch /t:Clean,Build # Clean between builds


### PR DESCRIPTION
Fixes #4
MacOS builds are of dubious quality
if we really need to, we could get rid of the setup-msbuild action, just running `refreshenv` in powershell might work too